### PR TITLE
Fix uninitialized variables and bad function calls

### DIFF
--- a/src/devheart.c
+++ b/src/devheart.c
@@ -8,6 +8,7 @@
 
 // use kernel module name in front of kernel log messages
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+#define CPUTIME_PER_USEC 4096ULL
 
 #include <linux/module.h>
 #include <linux/kernel.h>
@@ -72,7 +73,7 @@ static u64 get_idle_time(int cpu)
         idle = kcpustat_cpu(cpu).cpustat[CPUTIME_IDLE];
     }
     else {
-        idle = usecs_to_cputime64(idle_time);
+        idle = idle_time * CPUTIME_PER_USEC;
     }
 
     return idle;
@@ -91,7 +92,7 @@ static u64 get_iowait_time(int cpu)
         iowait = kcpustat_cpu(cpu).cpustat[CPUTIME_IOWAIT];
     }
     else {
-        iowait = usecs_to_cputime64(iowait_time);
+        iowait = iowait_time * CPUTIME_PER_USEC;
     }
 
     return iowait;
@@ -99,7 +100,8 @@ static u64 get_iowait_time(int cpu)
 
 void cpu_stat(u64 *idle_time, u64 *total_time) {
     int i;
-    u64 user, nice, system, idle, iowait, irq, softirq, steal = 0;
+    u64 user = 0, nice = 0, system = 0, idle = 0;
+    u64 iowait = 0, irq = 0, softirq = 0, steal = 0;
 
     for_each_possible_cpu(i) {
         user += kcpustat_cpu(i).cpustat[CPUTIME_USER];


### PR DESCRIPTION
`usecs_to_cputime64` doesn't seem to exist anymore, so I replaced it with a macro I found while browsing the linux source code suggesting that there is 4096 cputime per microsecond. May not apply to all platforms though perhaps?

Also, I'm getting a segfault when I actually try this code out. I don't think these changes would cause that though. I'm running 4.15.0-36.